### PR TITLE
Add Tailwind config

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Open [http://localhost:3000](http://localhost:3000) with your browser to see the
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+Tailwind CSS is configured in `tailwind.config.mjs`. Customize colors and fonts by editing the CSS variables in `src/app/globals.css` and extending them in the config.
+
 
 ## Learn More
 

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -1,0 +1,21 @@
+const config = {
+  content: [
+    "./pages/**/*.{js,ts,jsx,tsx}",
+    "./src/**/*.{js,ts,jsx,tsx}",
+  ],
+  theme: {
+    extend: {
+      colors: {
+        background: "var(--color-background)",
+        foreground: "var(--color-foreground)",
+      },
+      fontFamily: {
+        sans: "var(--font-sans)",
+        mono: "var(--font-mono)",
+      },
+    },
+  },
+  plugins: [],
+};
+
+export default config;


### PR DESCRIPTION
## Summary
- add a Tailwind config file with standard content globs
- document how to customize Tailwind

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68409d1f7d8c832580e77749b43b7ddd